### PR TITLE
Ringfence the playground

### DIFF
--- a/textual_query_sandbox/sandbox.py
+++ b/textual_query_sandbox/sandbox.py
@@ -190,7 +190,9 @@ class QuerySandboxApp(App[None]):
         self.query("Playground *").remove_class("hit")
         result: list[Widget] | Exception
         try:
-            result = list(self.playground.query(self.input.value).add_class("hit"))
+            result = list(
+                self.playground.query(f"Playground {self.input.value}").add_class("hit")
+            )
         except Exception as error:  # pylint:disable=broad-exception-caught
             result = error
         self.query_one("#results > Pretty", Pretty).update(result)


### PR DESCRIPTION
Because of the way queries work, if someone did a query like:

```scss
Playground > *
```

it would match all the widgets at the "top" level of the playground. Ideally we want to pretend that the playground is the whole universe. So here I prefix all queries with the playground CSS type to make it harder for there to be a clash.